### PR TITLE
add hook for logging

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -31,6 +31,8 @@ class PaymentsController < ApplicationController
     signer = CybersourceSigner.new(profile)
     signature_checker = SignatureChecker.new(profile, params, true)
     signature_checker.run!
+    # This can also be called with a block, which will return results for logging
+    #signature_checker.run! { |result| Rails.logger.debug result}
     @payment = Payment.new(signer, profile, params)
   rescue Exceptions::CybersourceryError => e
     flash.now[:alert] = e.message

--- a/lib/cybersource_response_handler.rb
+++ b/lib/cybersource_response_handler.rb
@@ -47,10 +47,9 @@ class CybersourceResponseHandler
     @profile = profile
   end
 
-  def run
-    @signature_checker.run!
+  def run(&block)
+    @signature_checker.run!(&block)
     check_for_transaction_errors
-    # TODO: add logging hook
     @profile.success_url
   end
 

--- a/lib/signature_checker.rb
+++ b/lib/signature_checker.rb
@@ -8,11 +8,21 @@ class SignatureChecker
   end
 
   def run
-    signature == CybersourceSigner::Signer.signature(signature_message, @profile.secret_key)
+    signature_valid = signature == CybersourceSigner::Signer.signature(signature_message, @profile.secret_key)
+
+    if block_given?
+      yield({
+        signature_valid: signature_valid,
+        profile_id: @profile.profile_id,
+        params: @params
+      })
+    end
+
+    signature_valid
   end
 
-  def run!
-    raise Exceptions::CybersourceryError, 'Detected possible data tampering. Signatures do not match.' unless run
+  def run!(&block)
+    raise Exceptions::CybersourceryError, 'Detected possible data tampering. Signatures do not match.' unless run(&block)
   end
 
   private

--- a/spec/lib/signature_checker_spec.rb
+++ b/spec/lib/signature_checker_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe SignatureChecker do
-  let(:profile) { double :profile, secret_key: 'SECRET_KEY' }
+  let(:profile) { double :profile, profile_id: 'pwksgem', secret_key: 'SECRET_KEY' }
   let(:signature) { 'vWV/HxXelIWsO0tkLZe+H1S6tXflgPz79udP0uXrvPI=' }
 
   context 'Checking signature when returning from a successful Cybersource transaction' do
@@ -30,6 +30,18 @@ describe SignatureChecker do
           'Detected possible data tampering. Signatures do not match.'
         )
       end
+
+      it 'yields data about the transaction if passed a block' do
+        checker = SignatureChecker.new(profile, params)
+        checker.run! { |results|
+          expect(results).to match a_hash_including(
+            signature_valid: true,
+            profile_id: 'pwksgem',
+            params: params
+          )
+        }
+      end
+
     end
   end
 


### PR DESCRIPTION
Have the signatureChecker yield to a block after it checks the signature, and pass back data on the current state. This can support arbitrary logging. The signatureChecker is  good place for this, as it can provide logging data for the both the shopping cart form submission and the credit card form submissions
